### PR TITLE
[Feature] Parallelize Training Loop

### DIFF
--- a/snake-ai/snake_ai/episodes.py
+++ b/snake-ai/snake_ai/episodes.py
@@ -3,7 +3,10 @@ from torch.utils.data import Dataset
 from dataclasses import dataclass, field
 from bisect import bisect_right
 from .model import ActorCritic
-from gymnasium.vector import VectorEnv
+from gymnasium.vector import VectorEnv, SyncVectorEnv
+from gymnasium import Env
+from gymnasium.wrappers.time_limit import TimeLimit
+import copy
 import numpy as np
 import torch
 
@@ -77,9 +80,29 @@ class EpisodeDataset(Dataset):
         return self.total
 
 
+def prepare_environment(env: Env, t: int, num_envs: int):
+    """
+    Returns a vectorized environment where each
+    individual environment is limited to at most t samples
+
+    Arguments:
+        env (Env): the environment to wrap
+        t (int): the maximum number of samples to collect before resetting the env
+        num_envs (int): the number of environments to create
+
+    Returns:
+        env (VectorEnv): the vectorized environment
+    """
+
+    def make_env():
+        c = copy.deepcopy(env)
+        return TimeLimit(c, t)
+
+    return SyncVectorEnv([make_env for _ in range(num_envs)])
+
+
 def collect_samples(
     samples: int,
-    t: int,
     model: ActorCritic,
     env: VectorEnv,
     device: str,
@@ -90,7 +113,6 @@ def collect_samples(
 
     Arguments:
         samples (int): the number of samples to collect
-        t (int): the maximum number of samples to collect before resetting the env
         model (ActorCritic): the actor-critic
         env (Env): the environment to use
         device (str): the device to use

--- a/snake-ai/snake_ai/episodes.py
+++ b/snake-ai/snake_ai/episodes.py
@@ -1,0 +1,179 @@
+from typing import List, Tuple, Union
+from torch.utils.data import Dataset
+from dataclasses import dataclass, field
+from bisect import bisect_right
+from .model import CNNActorCritic, MLPActorCritic
+from gymnasium.vector import VectorEnv
+import numpy as np
+import torch
+
+
+@dataclass
+class EpisodeRecord:
+    states: torch.Tensor
+    values: torch.Tensor
+    rewards: torch.Tensor
+    actions: torch.Tensor
+    probs: torch.Tensor
+    advantages: torch.Tensor = field(init=False)
+    target_values: torch.Tensor = field(init=False)
+    T: int = field(init=False)
+
+    def __post_init__(self):
+        self.T = self.states.shape[0]
+        self.advantages = None
+        self.target_values = None
+
+    def calculate(self, gamma: float, lam: float):
+        # deltas[i] = how much better state i+1 is compared to state i
+        deltas = []
+        for t in range(self.T - 1):
+            deltas.append(self.rewards[t] + gamma * self.values[t + 1] - self.values[t])
+        deltas.append(0)
+
+        # instead of doing the N^2 version of calculating advantages,
+        # go from the back instead
+        advantages = torch.zeros((len(deltas),))
+        # set the last item
+        advantages[-1] = deltas[-1]
+        for t in range(self.T - 2, -1, -1):
+            advantages[t] = deltas[t] + (lam * gamma) * advantages[t + 1]
+        self.advantages = advantages
+
+        # also calculate target values
+        # target value should just be the discounted future reward
+        self.target_values = self.advantages + self.values
+
+
+class EpisodeDataset(Dataset):
+    def __init__(self, records: List[EpisodeRecord]):
+        super().__init__()
+        self.records = records
+
+        # figure out what index every episode should start at
+        self.starts = []
+        cur = 0
+        for record in records:
+            self.starts.append(cur)
+            # there's actually only T-1 observations (since only T-1 advantages)
+            cur += record.T - 1
+        self.total = cur  # total amount of observations
+
+    def __getitem__(self, index):
+        record_idx = bisect_right(self.starts, index) - 1
+        episode_idx = index - self.starts[record_idx]
+        item = self.records[record_idx]
+        return {
+            "states": item.states[episode_idx],
+            "values": item.values[episode_idx],
+            "target_values": item.target_values[episode_idx],
+            "actions": item.actions[episode_idx],
+            "probs": item.probs[episode_idx],
+            "rewards": item.rewards[episode_idx],
+            "advantages": item.advantages[episode_idx],
+        }
+
+    def __len__(self):
+        return self.total
+
+
+def collect_samples(
+    samples: int,
+    t: int,
+    model: Union[CNNActorCritic, MLPActorCritic],
+    env: VectorEnv,
+    device: str,
+) -> Tuple[List[EpisodeRecord], float, float]:
+    """
+    Collects `samples` samples from the environment, resetting it at first
+    Assumes that model.get_value and model.get_action have gradients
+
+    Arguments:
+        samples (int): the number of samples to collect
+        t (int): the maximum number of samples to collect before resetting the env
+        model (Union[CNNActorCritic, MLPActorCritic]): the actor-critic
+        env (Env): the environment to use
+        device (str): the device to use
+
+    Returns:
+        ret (Tuple[List[EpisodeRecord], float, float): a tuple containing
+            the list of episode records, the mean reward, and the mean
+            episode length
+    """
+    cur_states = [[] for _ in range(env.num_envs)]
+    cur_values = [[] for _ in range(env.num_envs)]
+    cur_rewards = [[] for _ in range(env.num_envs)]
+    cur_actions = [[] for _ in range(env.num_envs)]
+    cur_probs = [[] for _ in range(env.num_envs)]
+    records = []
+
+    obs, _ = env.reset()
+    cur_length = [0 for _ in range(env.num_envs)]
+    cur_reward = [0 for _ in range(env.num_envs)]
+
+    logged_samples = 0
+    total_reward = 0
+    total_length = 0
+    while logged_samples < samples:
+        # take current and prepare to step
+        for e in range(env.num_envs):
+            cur_states[e].append(obs[e])
+        action, prob, value = model.predict_batched(
+            torch.tensor(obs).to(device), deterministic=False
+        )
+        action = action.cpu().numpy()
+        prob = prob.cpu().numpy()
+        value = value.cpu().numpy()
+
+        for e in range(env.num_envs):
+            cur_values[e].append(value[e])
+            cur_actions[e].append(action[e])
+            cur_probs[e].append(prob[e])
+
+        # step in the environment
+        obs, reward, terminated, truncated, _ = env.step(action)
+        for e in range(env.num_envs):
+            cur_rewards[e].append(reward[e])
+            cur_reward[e] += reward[e]
+
+        for e in range(env.num_envs):
+            if terminated[e] or truncated[e]:
+                logged_samples += cur_length[e]
+                if cur_length[e] > 2:
+                    # new episode
+                    records.append(
+                        EpisodeRecord(
+                            states=torch.from_numpy(np.array(cur_states[e])),
+                            values=torch.tensor(cur_values[e]),
+                            rewards=torch.tensor(cur_rewards[e]),
+                            actions=torch.tensor(cur_actions[e]),
+                            probs=torch.tensor(cur_probs[e]),
+                        )
+                    )
+                    total_reward += cur_reward[e]
+                    total_length += cur_length[e]
+
+                # environments autoreset, so simply take care of these
+                cur_rewards[e] = []
+                cur_states[e] = []
+                cur_values[e] = []
+                cur_length[e] = 0
+                cur_reward[e] = 0
+            cur_length[e] += 1
+
+    # in case we have extra remaining that we didn't include in the list yet
+    for e in range(env.num_envs):
+        if cur_length[e] > 2:
+            # new episode
+            records.append(
+                EpisodeRecord(
+                    states=torch.tensor(np.array(cur_states[e])),
+                    values=torch.tensor(cur_values[e]),
+                    rewards=torch.tensor(cur_rewards[e]),
+                    actions=torch.tensor(cur_actions[e]),
+                    probs=torch.tensor(cur_probs[e]),
+                )
+            )
+            total_reward += cur_reward[e]
+            total_length += cur_length[e]
+    return records, total_reward / len(records), total_length / len(records)

--- a/snake-ai/snake_ai/episodes.py
+++ b/snake-ai/snake_ai/episodes.py
@@ -1,8 +1,8 @@
-from typing import List, Tuple, Union
+from typing import List, Tuple
 from torch.utils.data import Dataset
 from dataclasses import dataclass, field
 from bisect import bisect_right
-from .model import CNNActorCritic, MLPActorCritic
+from .model import ActorCritic
 from gymnasium.vector import VectorEnv
 import numpy as np
 import torch
@@ -80,7 +80,7 @@ class EpisodeDataset(Dataset):
 def collect_samples(
     samples: int,
     t: int,
-    model: Union[CNNActorCritic, MLPActorCritic],
+    model: ActorCritic,
     env: VectorEnv,
     device: str,
 ) -> Tuple[List[EpisodeRecord], float, float]:
@@ -91,7 +91,7 @@ def collect_samples(
     Arguments:
         samples (int): the number of samples to collect
         t (int): the maximum number of samples to collect before resetting the env
-        model (Union[CNNActorCritic, MLPActorCritic]): the actor-critic
+        model (ActorCritic): the actor-critic
         env (Env): the environment to use
         device (str): the device to use
 

--- a/snake-ai/snake_ai/model.py
+++ b/snake-ai/snake_ai/model.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import torch
 
 
-class ActorCritic(nn.Module):
+class CNNActorCritic(nn.Module):
     def __init__(
         self,
         input_shape: Tuple[int, int, int],
@@ -20,7 +20,7 @@ class ActorCritic(nn.Module):
         dropout_rate: float = 0.1,
     ):
         # convolutional network
-        super(ActorCritic, self).__init__()
+        super(CNNActorCritic, self).__init__()
 
         self.gelu = nn.GELU()
         self.selu = nn.SELU()
@@ -69,9 +69,7 @@ class ActorCritic(nn.Module):
                 of the shape (B,)
         """
 
-        x: torch.Tensor = self.gelu(
-            self.preconv(states.float().unsqueeze(1).unsqueeze(1))
-        )
+        x: torch.Tensor = self.gelu(self.preconv(states.float()))
         # B, H, W, C -> B, C, H, W
         x = x.permute(0, 3, 1, 2).contiguous()
 
@@ -90,7 +88,7 @@ class ActorCritic(nn.Module):
     ) -> Tuple[int, float]:
         """
         Convenience method to predict the (discrete) action
-        to take given a nonbatched state, its probability, and its value.
+        to take, its probability, and its value given a nonbatched state.
 
         Arguments:
             state (torch.Tensor): the current state, nonbatched. Shape
@@ -106,3 +104,128 @@ class ActorCritic(nn.Module):
         else:
             idx = probs.multinomial(1)
         return idx.item(), probs[idx].item(), vals.squeeze().item()
+
+    def predict_batched(
+        self, state: torch.Tensor, deterministic: bool = True
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Convenience method to predict the (discrete) action to take, its probability, and its value
+        given the batched current states
+
+        Arguments:
+            state (torch.Tensor): the current state, batched. Shape
+                should be (B, *state_dims)
+        Returns:
+            items (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): the discrete actions to take (B,),
+                their probability (B,), and their respective predicted values (B,)
+        """
+        with torch.no_grad():
+            probs, vals = self(state)
+        if deterministic:
+            actions = probs.argmax(dim=-1)
+        else:
+            actions = probs.multinomial(1)
+        actions = actions.squeeze()
+
+        return (
+            actions,
+            probs[torch.arange(probs.shape[0]), actions],
+            vals.squeeze(),
+        )
+
+
+class MLPActorCritic(nn.Module):
+    def __init__(
+        self,
+        num_actions: int,
+        state_dim: int,
+        hidden_dim: int,
+    ):
+        # simple mlp network
+        super(MLPActorCritic, self).__init__()
+
+        self.softmax = nn.Softmax(dim=1)
+
+        self.shared = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+        )
+
+        self.prob_dense = nn.Sequential(
+            nn.Linear(hidden_dim, num_actions),
+        )
+        self.val_dense = nn.Sequential(
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Calls the model to predict the action probabilities and values B states
+
+        Arguments:
+            states (torch.Tensor): the states to predict action probabilities
+                for. Shape should be (B, *state_dims)
+
+        Returns:
+            items (Tuple[torch.Tensor, torch.Tensor]): a tuple of (probabilities, values), where
+                probabilities is a tensor of the shape (B, action_space) and values is a tensor
+                of the shape (B,)
+        """
+
+        x = self.shared(states)
+        # calculate probability logits and value
+        probs = self.softmax(self.prob_dense(x))
+        vals = self.val_dense(x)
+        return probs, vals
+
+    def predict(
+        self, state: torch.Tensor, deterministic: bool = True
+    ) -> Tuple[int, float]:
+        """
+        Convenience method to predict the (discrete) action
+        to take, its probability, and its value given a nonbatched state.
+
+        Arguments:
+            state (torch.Tensor): the current state, nonbatched. Shape
+                should be (*state_dims)
+        Returns:
+            items (Tuple[int, float, float]): the discrete action to take, its probability, and its predicted value
+        """
+        with torch.no_grad():
+            probs, vals = self(state.unsqueeze(0))
+        probs: torch.Tensor = probs.squeeze()
+        if deterministic:
+            idx = probs.argmax()
+        else:
+            idx = probs.multinomial(1)
+        return idx.item(), probs[idx].item(), vals.squeeze().item()
+
+    def predict_batched(
+        self, state: torch.Tensor, deterministic: bool = True
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Convenience method to predict the (discrete) action to take, its probability, and its value
+        given the batched current states
+
+        Arguments:
+            state (torch.Tensor): the current state, batched. Shape
+                should be (B, *state_dims)
+        Returns:
+            items (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): the discrete actions to take (B,),
+                their probability (B,), and their respective predicted values (B,)
+        """
+        with torch.no_grad():
+            probs, vals = self(state)
+        if deterministic:
+            actions = probs.argmax(dim=-1)
+        else:
+            actions = probs.multinomial(1)
+        actions = actions.squeeze()
+
+        return (
+            actions,
+            probs[torch.arange(probs.shape[0]), actions],
+            vals.squeeze(),
+        )

--- a/snake-ai/snake_ai/model.py
+++ b/snake-ai/snake_ai/model.py
@@ -70,13 +70,12 @@ class ActorCritic(nn.Module):
         if deterministic:
             actions = probs.argmax(dim=-1)
         else:
-            actions = probs.multinomial(1)
-        actions = actions.squeeze()
+            actions = probs.multinomial(1).squeeze(dim=-1)
 
         return (
             actions,
             probs[torch.arange(probs.shape[0]), actions],
-            vals.squeeze(),
+            vals.squeeze(dim=-1),
         )
 
 

--- a/snake-ai/snake_ai/model.py
+++ b/snake-ai/snake_ai/model.py
@@ -7,9 +7,80 @@ This file contains the code for a shared-weights actor-critic model.
 from typing import Tuple
 import torch.nn as nn
 import torch
+from abc import abstractmethod
 
 
-class CNNActorCritic(nn.Module):
+class ActorCritic(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @abstractmethod
+    def forward(self, states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Calls the model to predict the action probabilities and values B states
+
+        Arguments:
+            states (torch.Tensor): the states to predict action probabilities
+                for. Shape should be (B, *state_dims)
+
+        Returns:
+            items (Tuple[torch.Tensor, torch.Tensor]): a tuple of (probabilities, values), where
+                probabilities is a tensor of the shape (B, action_space) and values is a tensor
+                of the shape (B,)
+        """
+
+    def predict(
+        self, state: torch.Tensor, deterministic: bool = True
+    ) -> Tuple[int, float, float]:
+        """
+        Convenience method to predict the (discrete) action
+        to take, its probability, and its value given a nonbatched state.
+
+        Arguments:
+            state (torch.Tensor): the current state, nonbatched. Shape
+                should be (*state_dims)
+        Returns:
+            items (Tuple[int, float, float]): the discrete action to take, its probability, and its predicted value
+        """
+        with torch.no_grad():
+            probs, vals = self(state.unsqueeze(0))
+        probs: torch.Tensor = probs.squeeze()
+        if deterministic:
+            idx = probs.argmax()
+        else:
+            idx = probs.multinomial(1)
+        return idx.item(), probs[idx].item(), vals.squeeze().item()
+
+    def predict_batched(
+        self, state: torch.Tensor, deterministic: bool = True
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Convenience method to predict the (discrete) action to take, its probability, and its value
+        given the batched current states
+
+        Arguments:
+            state (torch.Tensor): the current state, batched. Shape
+                should be (B, *state_dims)
+        Returns:
+            items (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): the discrete actions to take (B,),
+                their probability (B,), and their respective predicted values (B,)
+        """
+        with torch.no_grad():
+            probs, vals = self(state)
+        if deterministic:
+            actions = probs.argmax(dim=-1)
+        else:
+            actions = probs.multinomial(1)
+        actions = actions.squeeze()
+
+        return (
+            actions,
+            probs[torch.arange(probs.shape[0]), actions],
+            vals.squeeze(),
+        )
+
+
+class CNNActorCritic(ActorCritic):
     def __init__(
         self,
         input_shape: Tuple[int, int, int],
@@ -83,58 +154,8 @@ class CNNActorCritic(nn.Module):
         vals = self.val_dense(x)
         return probs, vals
 
-    def predict(
-        self, state: torch.Tensor, deterministic: bool = True
-    ) -> Tuple[int, float]:
-        """
-        Convenience method to predict the (discrete) action
-        to take, its probability, and its value given a nonbatched state.
 
-        Arguments:
-            state (torch.Tensor): the current state, nonbatched. Shape
-                should be (*state_dims)
-        Returns:
-            items (Tuple[int, float, float]): the discrete action to take, its probability, and its predicted value
-        """
-        with torch.no_grad():
-            probs, vals = self(state.unsqueeze(0))
-        probs: torch.Tensor = probs.squeeze()
-        if deterministic:
-            idx = probs.argmax()
-        else:
-            idx = probs.multinomial(1)
-        return idx.item(), probs[idx].item(), vals.squeeze().item()
-
-    def predict_batched(
-        self, state: torch.Tensor, deterministic: bool = True
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Convenience method to predict the (discrete) action to take, its probability, and its value
-        given the batched current states
-
-        Arguments:
-            state (torch.Tensor): the current state, batched. Shape
-                should be (B, *state_dims)
-        Returns:
-            items (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): the discrete actions to take (B,),
-                their probability (B,), and their respective predicted values (B,)
-        """
-        with torch.no_grad():
-            probs, vals = self(state)
-        if deterministic:
-            actions = probs.argmax(dim=-1)
-        else:
-            actions = probs.multinomial(1)
-        actions = actions.squeeze()
-
-        return (
-            actions,
-            probs[torch.arange(probs.shape[0]), actions],
-            vals.squeeze(),
-        )
-
-
-class MLPActorCritic(nn.Module):
+class MLPActorCritic(ActorCritic):
     def __init__(
         self,
         num_actions: int,
@@ -179,53 +200,3 @@ class MLPActorCritic(nn.Module):
         probs = self.softmax(self.prob_dense(x))
         vals = self.val_dense(x)
         return probs, vals
-
-    def predict(
-        self, state: torch.Tensor, deterministic: bool = True
-    ) -> Tuple[int, float]:
-        """
-        Convenience method to predict the (discrete) action
-        to take, its probability, and its value given a nonbatched state.
-
-        Arguments:
-            state (torch.Tensor): the current state, nonbatched. Shape
-                should be (*state_dims)
-        Returns:
-            items (Tuple[int, float, float]): the discrete action to take, its probability, and its predicted value
-        """
-        with torch.no_grad():
-            probs, vals = self(state.unsqueeze(0))
-        probs: torch.Tensor = probs.squeeze()
-        if deterministic:
-            idx = probs.argmax()
-        else:
-            idx = probs.multinomial(1)
-        return idx.item(), probs[idx].item(), vals.squeeze().item()
-
-    def predict_batched(
-        self, state: torch.Tensor, deterministic: bool = True
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Convenience method to predict the (discrete) action to take, its probability, and its value
-        given the batched current states
-
-        Arguments:
-            state (torch.Tensor): the current state, batched. Shape
-                should be (B, *state_dims)
-        Returns:
-            items (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): the discrete actions to take (B,),
-                their probability (B,), and their respective predicted values (B,)
-        """
-        with torch.no_grad():
-            probs, vals = self(state)
-        if deterministic:
-            actions = probs.argmax(dim=-1)
-        else:
-            actions = probs.multinomial(1)
-        actions = actions.squeeze()
-
-        return (
-            actions,
-            probs[torch.arange(probs.shape[0]), actions],
-            vals.squeeze(),
-        )

--- a/snake-ai/snake_ai/trainer.py
+++ b/snake-ai/snake_ai/trainer.py
@@ -6,180 +6,22 @@ model using the PPO algorithm.
 """
 
 import torch
+from typing import Union
 from torch.optim import Optimizer
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader
 import numpy as np
-from gymnasium import Env
-from typing import List, Tuple
-from .model import ActorCritic
-from dataclasses import dataclass, field
-from bisect import bisect_right
+from gymnasium.vector import VectorEnv
+from .model import CNNActorCritic, MLPActorCritic
 from tqdm import tqdm
 from torch.utils.tensorboard.writer import SummaryWriter
-
-
-@dataclass
-class EpisodeRecord:
-    states: torch.Tensor
-    values: torch.Tensor
-    rewards: torch.Tensor
-    actions: torch.Tensor
-    probs: torch.Tensor
-    advantages: torch.Tensor = field(init=False)
-    target_values: torch.Tensor = field(init=False)
-    T: int = field(init=False)
-
-    def __post_init__(self):
-        self.T = self.states.shape[0]
-        self.advantages = None
-        self.target_values = None
-
-    def calculate(self, gamma: float, lam: float):
-        # deltas[i] = how much better state i+1 is compared to state i
-        deltas = []
-        for t in range(self.T - 1):
-            deltas.append(self.rewards[t] + gamma * self.values[t + 1] - self.values[t])
-        deltas.append(0)
-
-        # instead of doing the N^2 version of calculating advantages,
-        # go from the back instead
-        advantages = torch.zeros((len(deltas),))
-        # set the last item
-        advantages[-1] = deltas[-1]
-        for t in range(self.T - 2, -1, -1):
-            advantages[t] = deltas[t] + (lam * gamma) * advantages[t + 1]
-        self.advantages = advantages
-
-        # also calculate target values
-        # target value should just be the discounted future reward
-        self.target_values = self.advantages + self.values
-
-
-class EpisodeDataset(Dataset):
-    def __init__(self, records: List[EpisodeRecord]):
-        super().__init__()
-        self.records = records
-
-        # figure out what index every episode should start at
-        self.starts = []
-        cur = 0
-        for record in records:
-            self.starts.append(cur)
-            # there's actually only T-1 observations (since only T-1 advantages)
-            cur += record.T - 1
-        self.total = cur  # total amount of observations
-
-    def __getitem__(self, index):
-        record_idx = bisect_right(self.starts, index) - 1
-        episode_idx = index - self.starts[record_idx]
-        item = self.records[record_idx]
-        return {
-            "states": item.states[episode_idx],
-            "values": item.values[episode_idx],
-            "target_values": item.target_values[episode_idx],
-            "actions": item.actions[episode_idx],
-            "probs": item.probs[episode_idx],
-            "rewards": item.rewards[episode_idx],
-            "advantages": item.advantages[episode_idx],
-        }
-
-    def __len__(self):
-        return self.total
-
-
-def collect_samples(
-    samples: int, t: int, model: ActorCritic, env: Env, device: str
-) -> Tuple[List[EpisodeRecord], float, float]:
-    """
-    Collects `samples` samples from the environment, resetting it at first
-    Assumes that model.get_value and model.get_action have gradients
-
-    Arguments:
-        samples (int): the number of samples to collect
-        t (int): the maximum number of samples to collect before resetting the env
-        model (ActorCritic): the actor-critic
-        env (Env): the environment to use
-        device (str): the device to use
-
-    Returns:
-        ret (Tuple[List[EpisodeRecord], float, float): a tuple containing
-            the list of episode records, the mean reward, and the mean
-            episode length
-    """
-    cur_states = []
-    cur_values = []
-    cur_rewards = []
-    cur_actions = []
-    cur_probs = []
-    records = []
-
-    obs, _ = env.reset()
-    num_samples = 0
-    cur_length = 0
-    cur_reward = 0
-    total_reward = 0
-    total_length = 0
-    while num_samples < samples:
-        # take current and prepare to step
-        cur_states.append(obs)
-        action, prob, value = model.predict(
-            torch.tensor(obs).to(device), deterministic=False
-        )
-        cur_values.append(value)
-        cur_actions.append(action)
-        cur_probs.append(prob)
-
-        # step in the environment
-        obs, reward, terminated, truncated, _ = env.step(action)
-        cur_rewards.append(reward)
-        cur_reward += reward
-
-        if terminated or truncated or cur_length >= t:
-            if cur_length > 2:
-                # new episode
-                records.append(
-                    EpisodeRecord(
-                        states=torch.tensor(np.array(cur_states)),
-                        values=torch.tensor(cur_values),
-                        rewards=torch.tensor(cur_rewards),
-                        actions=torch.tensor(cur_actions),
-                        probs=torch.tensor(cur_probs),
-                    )
-                )
-                total_reward += cur_reward
-                total_length += cur_length
-
-            cur_rewards = []
-            cur_states = []
-            cur_values = []
-            cur_length = 0
-            cur_reward = 0
-            # reset the environment
-            obs, _ = env.reset()
-        num_samples += 1
-        cur_length += 1
-
-    # in case we have extra remaining that we didn't include in the list yet
-    if cur_length > 2:
-        # new episode
-        records.append(
-            EpisodeRecord(
-                states=torch.tensor(np.array(cur_states)),
-                values=torch.tensor(cur_values),
-                rewards=torch.tensor(cur_rewards),
-                actions=torch.tensor(cur_actions),
-                probs=torch.tensor(cur_probs),
-            )
-        )
-        total_reward += cur_reward
-        total_length += cur_length
-    return records, total_reward / len(records), total_length / len(records)
+from .episodes import collect_samples, EpisodeDataset
+from datetime import datetime
 
 
 def train(
-    model: ActorCritic,
+    model: Union[CNNActorCritic, MLPActorCritic],
     optimizer: Optimizer,
-    env: Env,
+    env: VectorEnv,
     iterations: int,
     t: int,
     samples: int,
@@ -201,7 +43,7 @@ def train(
     Train an actor-critic model in the given environment using the PPO algorithm.
 
     Arguments:
-        model (ActorCritic): the actor-critic model to train
+        model (Union[CNNActorCritic, MLPActorCritic]): the actor-critic model to train
         optimizer (Optimizer): the optimizer to use
         env (Env): the environment to train in
         iterations (int): the number of iterations to train
@@ -229,11 +71,16 @@ def train(
     for iteration in range(iterations):
         print(f"iteration {iteration+1}")
         model.eval()
+        time_start = datetime.now()
         episodes, mean_reward, mean_length = collect_samples(
             samples, t, model, env, device
         )
+        time_end = datetime.now()
         writer.add_scalar("env/mean_reward", mean_reward, i)
         writer.add_scalar("env/mean_length", mean_length, i)
+        writer.add_scalar(
+            "env/collection_time", (time_end - time_start).total_seconds(), i
+        )
 
         # calculate advantages
         for episode in episodes:
@@ -344,10 +191,10 @@ def train(
         # more logging
         prog.close()
         print(
-            f"Average epoch loss {total_loss/total_items:.4f},"
-            f" lclip {total_lclip/total_items:.4f},"
-            f" lvf {total_lvf/total_items:.4f},"
-            f" lent {total_lentropy/total_items:.4f}"
+            f"Average epoch loss {total_loss/total_items:.4f},",
+            f"lclip {total_lclip/total_items:.4f},",
+            f"lvf {total_lvf/total_items:.4f},",
+            f"lent {total_lentropy/total_items:.4f}",
         )
 
     model.eval()

--- a/snake-ai/snake_ai/trainer.py
+++ b/snake-ai/snake_ai/trainer.py
@@ -6,12 +6,11 @@ model using the PPO algorithm.
 """
 
 import torch
-from typing import Union
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 import numpy as np
 from gymnasium.vector import VectorEnv
-from .model import CNNActorCritic, MLPActorCritic
+from .model import ActorCritic
 from tqdm import tqdm
 from torch.utils.tensorboard.writer import SummaryWriter
 from .episodes import collect_samples, EpisodeDataset
@@ -19,7 +18,7 @@ from datetime import datetime
 
 
 def train(
-    model: Union[CNNActorCritic, MLPActorCritic],
+    model: ActorCritic,
     optimizer: Optimizer,
     env: VectorEnv,
     iterations: int,
@@ -43,7 +42,7 @@ def train(
     Train an actor-critic model in the given environment using the PPO algorithm.
 
     Arguments:
-        model (Union[CNNActorCritic, MLPActorCritic]): the actor-critic model to train
+        model (ActorCritic): the actor-critic model to train
         optimizer (Optimizer): the optimizer to use
         env (Env): the environment to train in
         iterations (int): the number of iterations to train

--- a/snake-ai/snake_ai/trainer.py
+++ b/snake-ai/snake_ai/trainer.py
@@ -9,20 +9,21 @@ import torch
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 import numpy as np
-from gymnasium.vector import VectorEnv
+from gymnasium import Env
 from .model import ActorCritic
 from tqdm import tqdm
 from torch.utils.tensorboard.writer import SummaryWriter
-from .episodes import collect_samples, EpisodeDataset
+from .episodes import prepare_environment, collect_samples, EpisodeDataset
 from datetime import datetime
 
 
 def train(
     model: ActorCritic,
     optimizer: Optimizer,
-    env: VectorEnv,
+    env: Env,
     iterations: int,
     t: int,
+    num_envs: int,
     samples: int,
     batch_size: int,
     epochs: int,
@@ -37,6 +38,7 @@ def train(
     clip_norm_val: float = 2.0,
     normalize_advantages: bool = False,
 ):
+
     # see page 5 of https://arxiv.org/pdf/1707.06347
     """
     Train an actor-critic model in the given environment using the PPO algorithm.
@@ -47,6 +49,7 @@ def train(
         env (Env): the environment to train in
         iterations (int): the number of iterations to train
         t (int): the number of samples to take from each environment
+        num_envs (int): the number of environments to run in parallel
         samples (int): the number of samples to collect per iteration
         batch_size (int): the batch size for training
         epochs (int): the number of epochs to train per iteration
@@ -67,12 +70,14 @@ def train(
     writer.add_scalar("params/batch_size", batch_size, 0)
     writer.add_scalar("params/epochs", epochs, 0)
 
+    env = prepare_environment(env, t, num_envs)
+
     for iteration in range(iterations):
         print(f"iteration {iteration+1}")
         model.eval()
         time_start = datetime.now()
         episodes, mean_reward, mean_length = collect_samples(
-            samples, t, model, env, device
+            samples, model, env, device
         )
         time_end = datetime.now()
         writer.add_scalar("env/mean_reward", mean_reward, i)


### PR DESCRIPTION
This PR adds a `num_envs` parameter to the main training loop. This parameter controls the number of parallel environments that the agent interacts with. Increasing this parameter increases CPU utilization and accelerator utilization (due to the nature of batching).

This image shows the difference in performance between 1 environment and 5 parallel environments.
![image](https://github.com/user-attachments/assets/00a37918-daf4-41ce-b6ba-bd65dc50ce2a)

This PR also adds an MLPActorCritic, for testing purposes. Example usage below:
```python
import gymnasium as gym
import gymnasium.wrappers as wrappers
from snake_ai.trainer import train
from snake_ai.model import CNNActorCritic, MLPActorCritic

model = MLPActorCritic(4, 8, 64)

from torch.optim import Adam
optim = Adam(model.parameters(), 2e-4)

# LunarLander is an example where MLPActorCritic is useful; CNNActorCritic
# is more useful for our pixel-based snake game
env = gym.make("LunarLander-v2")
env.reset()

train(
    model,
    optim,
    env,
    100,
    1024,
    1,
    2048,
    64,
    10,
    0.99,
    0.95,
    0.2,
    ecf=0.,
    vcf=0.5,
    clip_norm_val=0.5,
    device="cuda",
    normalize_advantages=False,
    num_workers=12,
)
```